### PR TITLE
Atualizado versão do axios, devido a vulnerabilidade da versão 0.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
   },
   "homepage": "https://github.com/totalvoice/totalvoice-node#readme",
   "dependencies": {
-    "axios": "^0.17.0"
+    "axios": "^0.19.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
-    "jest": "^22.0.4"
+    "jest": "^24.8.0"
   }
 }


### PR DESCRIPTION
Atualizado a versão do axios devido a vulnerabilidade. Segue link [https://www.cvedetails.com/cve/CVE-2019-10742/]( https://www.cvedetails.com/cve/CVE-2019-10742/).

Atualizado a versão do Jest para **24.8.0**.