### PR TITLE
Updating Axios version due to vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/totalvoice/totalvoice-node#readme",
   "dependencies": {
-    "axios": "^0.19.0"
+    "axios": "^0.21.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
Need to update Axios due to vulnerabilities found in the 0.19.0 version. Summary of npm install with new version:

up to date, audited 82 packages in 1s

2 packages are looking for funding
  run `npm fund` for details
